### PR TITLE
Improve scroll behavior in NowGPT modal

### DIFF
--- a/public/js/nowgpt-modal.js
+++ b/public/js/nowgpt-modal.js
@@ -74,7 +74,10 @@ class NowGPTModal {
             responseText += data.content;
             responseDiv.querySelector(".message-text").innerHTML =
               marked.parse(responseText);
-            this.scrollToBottom();
+
+            if (this.isNearBottom()) {
+              this.scrollToBottom();
+            }
           }
         }
       }
@@ -286,21 +289,32 @@ How can I assist you today?`;
                         ${isUser ? content : content || ""}
                     </div>
                     ${
-                      !isUser
-                        ? `<div class="message-time">${timestamp}</div>`
-                        : ""
+                      isUser
+                        ? ""
+                        : `<div class="message-time">${timestamp}</div>`
                     }
                 </div>
             </div>
         `;
 
     this.messagesContainer.appendChild(messageDiv);
-    this.scrollToBottom();
+    if (this.isNearBottom()) {
+      this.scrollToBottom();
+    }
     return messageDiv;
   }
 
   scrollToBottom() {
     this.messagesContainer.scrollTop = this.messagesContainer.scrollHeight;
+  }
+
+  isNearBottom() {
+    const threshold = 100; // pixels from bottom
+    const scrollBottom =
+      this.messagesContainer.scrollHeight -
+      this.messagesContainer.scrollTop -
+      this.messagesContainer.clientHeight;
+    return scrollBottom < threshold;
   }
 }
 


### PR DESCRIPTION
- Add `isNearBottom()` method to conditionally scroll only when user is near the bottom of the chat
- Modify message rendering to only auto-scroll when user is close to the end of the conversation
- Prevent unnecessary scrolling that might disrupt user experience

## Summary by Sourcery

Improve the scroll behavior of the NowGPT modal to only scroll to the bottom when the user is near the bottom of the chat.

New Features:
- Implement conditional auto-scrolling to prevent unnecessary scrolling and improve user experience.

Enhancements:
- Introduce a new `isNearBottom()` method to check if the user is near the bottom of the messages container.